### PR TITLE
Implemented Remote Config

### DIFF
--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1283477dd1c2aa94bb3c765b7a0502f1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/RemoteConfig.meta
+++ b/Assets/Editor/RemoteConfig.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98cf220586a7e824e8634547cd06e713
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/RemoteConfig/Data.meta
+++ b/Assets/Editor/RemoteConfig/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f91fa2651b3e2614bac000a5ca0e71ac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/RemoteConfig/Data/RemoteConfigDataStoreAsset.asset
+++ b/Assets/Editor/RemoteConfig/Data/RemoteConfigDataStoreAsset.asset
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 469c24fdb3bd6431b92cc1465bd9166b, type: 3}
+  m_Name: RemoteConfigDataStoreAsset
+  m_EditorClassIdentifier: 
+  rsKeyList:
+  - metadata:
+      entityId: 0c82eb6a-1b0c-42a0-a222-9bc714708f6c
+    rs:
+      key: allowLog
+      type: bool
+      value: true
+  - metadata:
+      entityId: b54e7b83-6b10-4202-9cc4-e5496d706408
+    rs:
+      key: allowWarning
+      type: bool
+      value: true
+  - metadata:
+      entityId: 4d107591-056d-43ca-9d7b-72a16e5b8b16
+    rs:
+      key: allowError
+      type: bool
+      value: true
+  rsLastCachedKeyList:
+  - metadata:
+      entityId: 0c82eb6a-1b0c-42a0-a222-9bc714708f6c
+    rs:
+      key: allowLog
+      type: bool
+      value: true
+  - metadata:
+      entityId: b54e7b83-6b10-4202-9cc4-e5496d706408
+    rs:
+      key: allowWarning
+      type: bool
+      value: true
+  - metadata:
+      entityId: 4d107591-056d-43ca-9d7b-72a16e5b8b16
+    rs:
+      key: allowError
+      type: bool
+      value: true
+  configId: 5369982b-7513-489b-b575-0cadddd33bea
+  currentEnvironmentId: 26a60c50-260a-45c6-9ca3-6a3b7fdcf582
+  environments:
+  - id: 66550b1c-e205-49c9-bf72-319b8c52e7cf
+    appId: 
+    name: Release (Default)
+    description: 
+    createdAt: 2020-04-26T10:57:49Z
+    updatedAt: 2020-04-26T10:57:49Z
+  - id: 26a60c50-260a-45c6-9ca3-6a3b7fdcf582
+    appId: 
+    name: Development
+    description: 
+    createdAt: 2020-04-26T10:57:49Z
+    updatedAt: 2020-04-26T10:57:49Z
+  rulesList: []
+  lastCachedRulesList: []
+  addedRulesIDs: []
+  updatedRulesIDs: []
+  deletedRulesIDs: []

--- a/Assets/Editor/RemoteConfig/Data/RemoteConfigDataStoreAsset.asset.meta
+++ b/Assets/Editor/RemoteConfig/Data/RemoteConfigDataStoreAsset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e7fb176afbb44524cba816497e1edee8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Sirenix/Odin Inspector/Config/Resources.meta
+++ b/Assets/Plugins/Sirenix/Odin Inspector/Config/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f63e491835414fe449cb4c60fc4c4c9c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Sirenix/Odin Inspector/Config/Resources/Sirenix.meta
+++ b/Assets/Plugins/Sirenix/Odin Inspector/Config/Resources/Sirenix.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d27db82621441904788eb2b49be4500f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Sirenix/Odin Inspector/Config/Resources/Sirenix/GlobalSerializationConfig.asset
+++ b/Assets/Plugins/Sirenix/Odin Inspector/Config/Resources/Sirenix/GlobalSerializationConfig.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1549551891, guid: 74721b9f0af448f5ae2e91102a1a5edd, type: 3}
+  m_Name: GlobalSerializationConfig
+  m_EditorClassIdentifier: 
+  HideSerializationCautionaryMessage: 1
+  HidePrefabCautionaryMessage: 0
+  HideOdinSerializeAttributeWarningMessages: 0
+  HideNonSerializedShowInInspectorWarningMessages: 0
+  buildSerializationFormat: 0
+  editorSerializationFormat: 2
+  loggingPolicy: 0
+  errorHandlingPolicy: 0

--- a/Assets/Plugins/Sirenix/Odin Inspector/Config/Resources/Sirenix/GlobalSerializationConfig.asset.meta
+++ b/Assets/Plugins/Sirenix/Odin Inspector/Config/Resources/Sirenix/GlobalSerializationConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 89742eecfde052c41a9a5c0d18e750eb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Default.unity
+++ b/Assets/Scenes/Default.unity
@@ -156,7 +156,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 272.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &6684137
@@ -1156,7 +1156,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &351421867
 GameObject:
@@ -1664,7 +1664,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1 &647189862
 GameObject:
@@ -2729,7 +2729,7 @@ RectTransform:
   - {fileID: 875577820}
   - {fileID: 238523835}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2892,7 +2892,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &989626834
 GameObject:
@@ -3204,7 +3204,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1142756571
 GameObject:
@@ -3276,7 +3276,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1151768789
 GameObject:
@@ -3397,7 +3397,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 22451668, guid: 0abab5bb77339e4428787a870eb31bd3, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 22451668, guid: 0abab5bb77339e4428787a870eb31bd3, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3532,7 +3532,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1209830884
 GameObject:
@@ -5619,7 +5619,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 272.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1675939636
@@ -6292,7 +6292,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1790494210
 GameObject:
@@ -6354,6 +6354,71 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1790494210}
   m_CullTransparentMesh: 0
+--- !u!1 &1824509062
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1824509064}
+  - component: {fileID: 1824509063}
+  - component: {fileID: 1824509065}
+  m_Layer: 0
+  m_Name: Debugger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1824509063
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1824509062}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5b283851c5228c4fb6324f361964ed2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes: []
+--- !u!4 &1824509064
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1824509062}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1824509065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1824509062}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a8fe5d7fc897d8b4382ca0cc1bb63a54, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1945867892
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/DebugTool.cs
+++ b/Assets/Scripts/Core/DebugTool.cs
@@ -1,0 +1,77 @@
+﻿// Created by h1ddengames
+
+using System;
+using System.Collections.Generic;
+using Sirenix.OdinInspector;
+using Michsky.UI.ModernUIPack;
+using UnityEngine;
+using Unity.RemoteConfig;
+
+namespace h1ddengames.Core {
+    public class DebugTool : SerializedMonoBehaviour {
+        public struct userAttributes { }
+        public struct appAttributes { }
+
+        public static bool allowLog = false;
+        public static bool allowWarning = false;
+        public static bool allowError = false;
+
+        public static float updateTime = 120f;
+        private static float timer = 0f;
+
+        #region Exposed Fields
+        #endregion
+
+        #region Private Fields
+        #endregion
+
+        #region Getters/Setters/Constructors
+        #endregion
+
+        #region My Methods
+        public static void Log(object message) {
+            if(allowLog) {
+                Debug.Log(message);
+            }
+        }
+
+        public static void LogWarning(object message) {
+            if(allowWarning) {
+                Debug.LogWarning(message);
+            }
+        }
+
+        public static void LogError(object message) {
+            if(allowError) {
+                Debug.LogError(message);
+            }
+        }
+        #endregion
+
+        #region Unity Methods
+        private void Awake() {
+            ConfigManager.FetchCompleted += SetDisplayDebugStatements;
+            ConfigManager.FetchConfigs<userAttributes, appAttributes>(new userAttributes(), new appAttributes());
+        }
+
+        private void SetDisplayDebugStatements(ConfigResponse response) {
+            allowLog = ConfigManager.appConfig.GetBool("allowLog");
+            allowWarning = ConfigManager.appConfig.GetBool("allowWarning");
+            allowError = ConfigManager.appConfig.GetBool("allowError");
+        }
+
+        private void Update() {
+            timer += Time.deltaTime;
+
+            if(timer > updateTime) {
+                timer = 0f;
+                ConfigManager.FetchConfigs<userAttributes, appAttributes>(new userAttributes(), new appAttributes());
+                Log("Updated configs.");
+            }
+        }
+        #endregion
+
+        #region Helper Methods
+        #endregion
+    }
+}

--- a/Assets/Scripts/Core/DebugTool.cs.meta
+++ b/Assets/Scripts/Core/DebugTool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5b283851c5228c4fb6324f361964ed2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Test.meta
+++ b/Assets/Scripts/Test.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a46c5728650906540a7b7d0d8dfd5635
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Test/DebugToolTest.cs
+++ b/Assets/Scripts/Test/DebugToolTest.cs
@@ -1,0 +1,35 @@
+﻿// Created by h1ddengames
+
+using System;
+using System.Collections.Generic;
+using Sirenix.OdinInspector;
+using Michsky.UI.ModernUIPack;
+using UnityEngine;
+using h1ddengames.Core;
+
+namespace h1ddengames.Test {
+    public class DebugToolTest : MonoBehaviour {
+        #region Exposed Fields
+        #endregion
+
+        #region Private Fields
+        #endregion
+
+        #region Getters/Setters/Constructors
+        #endregion
+
+        #region My Methods
+        #endregion
+
+        #region Unity Methods
+        private void Update() {
+            DebugTool.Log("Log");
+            DebugTool.LogError("Error");
+            DebugTool.LogWarning("Warning");
+        }
+        #endregion
+
+        #region Helper Methods
+        #endregion
+    }
+}

--- a/Assets/Scripts/Test/DebugToolTest.cs.meta
+++ b/Assets/Scripts/Test/DebugToolTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8fe5d7fc897d8b4382ca0cc1bb63a54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -686,10 +686,10 @@ PlayerSettings:
     m_VersionCode: 1
     m_VersionName: 
   apiCompatibilityLevel: 6
-  cloudProjectId: 
+  cloudProjectId: 8d98263a-45db-4f93-9146-ca1214073c29
   framebufferDepthMemorylessMode: 0
-  projectName: 
-  organizationId: 
+  projectName: Motherload-Clone
+  organizationId: h1ddengames
   cloudEnabled: 0
   enableNativePlatformBackendsForNewInputSystem: 0
   disableOldInputManagerSupport: 0

--- a/ProjectSettings/UnityConnectSettings.asset
+++ b/ProjectSettings/UnityConnectSettings.asset
@@ -12,7 +12,7 @@ UnityConnectSettings:
   m_TestInitMode: 0
   CrashReportingSettings:
     m_EventUrl: https://perf-events.cloud.unity3d.com
-    m_Enabled: 0
+    m_Enabled: 1
     m_LogBufferSize: 10
     m_CaptureEditorExceptions: 1
   UnityPurchasingSettings:


### PR DESCRIPTION
Created DebugTool that replaces the Debug class as the default logger.
Using Remote Config, there are three settings (allowLog, allowWarning, and allowError) that can be changed remotely through the remote config dashboard.
Depending on if the above settings are enabled, the corresponding Debug messages (Log, LogWarning, LogError) will display.
Created DebugToolTest to test if DebugTool log messages are displayed properly depending on the value of allowLog, allowWarning, and allowError.
DebugToolTest also tests if remote config is being pulled at the start of the game as well as if remote configs can be pulled after a certain amount of time.

Signed-off-by: h1ddengames <skarim3000@gmail.com>